### PR TITLE
Add CPU fallback and debugging

### DIFF
--- a/analyze_example.py
+++ b/analyze_example.py
@@ -61,7 +61,9 @@ the task code, and it will:
 np.random.seed(0)
 torch.manual_seed(0)
 torch.set_default_dtype(torch.float32)
-torch.set_default_device('cuda')
+# Detect GPU availability at runtime.
+device = 'cuda' if torch.cuda.is_available() else 'cpu'
+torch.set_default_device(device)
 
 if __name__ == "__main__":
 

--- a/arc_compressor.py
+++ b/arc_compressor.py
@@ -8,7 +8,10 @@ import layers
 np.random.seed(0)
 torch.manual_seed(0)
 torch.set_default_dtype(torch.float32)
-torch.set_default_device('cuda')
+# Use GPU if available, otherwise fall back to CPU. The original code assumed
+# CUDA is always present which breaks in environments without a GPU.
+device = 'cuda' if torch.cuda.is_available() else 'cpu'
+torch.set_default_device(device)
 
 
 class ARCCompressor:

--- a/parallel_train.py
+++ b/parallel_train.py
@@ -33,7 +33,9 @@ import solve_task
 # Getting all the task names, setting defaults and constants
 multiprocessing.set_start_method('spawn', force=True)
 torch.set_default_dtype(torch.float32)
-torch.set_default_device('cuda')
+# Prefer GPU but fall back to CPU if unavailable.
+device = 'cuda' if torch.cuda.is_available() else 'cpu'
+torch.set_default_device(device)
 torch.backends.cudnn.benchmark = True
 torch.backends.cuda.matmul.allow_tf32 = True
 

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -134,7 +134,9 @@ class Task:
                     original_grid = example.get(
                         mode, np.zeros(self.shapes[new_idx][1])
                     )                               # 2-D list/ndarray (H,W)
-                    print(original_grid)
+                    # Debug: show grid if necessary. Commented out to reduce
+                    # verbosity during preprocessing.
+                    # print(original_grid)
                     if isinstance(original_grid, list):
                         original_grid = np.array(original_grid)
                     if original_grid.ndim != 2:
@@ -165,6 +167,14 @@ class Task:
                         self.input_attr_tensor.append(obj_attrs_tensor)
                     else:
                         self.output_attr_tensor.append(obj_attrs_tensor)
+
+                    # Debug: inspect hole features for the first few objects of
+                    # the first training example.
+                    if subsplit == 'train' and example_num == 0 and len(obj_d) > 0:
+                        from utils.attr_registry import key_index
+                        h_start = key_index('holes')
+                        h_vec = obj_attrs_tensor[:, h_start:h_start+9]
+                        print(f"[DEBUG] Example {new_idx} {mode} holes one-hot:", h_vec[:5].tolist())
 
 
 

--- a/solve_task.py
+++ b/solve_task.py
@@ -43,8 +43,12 @@ def solve_task(task_name, split, time_limit, n_train_iterations, gpu_id, memory_
 
     try:  # Error catching block that puts errors on the error_queue
 
-        torch.set_default_device('cuda')
-        torch.cuda.set_device(gpu_id)
+        # Set the default device based on availability. When running on CPU only
+        # this avoids an initialization error.
+        device = 'cuda' if torch.cuda.is_available() else 'cpu'
+        torch.set_default_device(device)
+        if device == 'cuda':
+            torch.cuda.set_device(gpu_id)
         torch.cuda.reset_peak_memory_stats()  # Measure the memory used.
 
         # Get the task

--- a/train.py
+++ b/train.py
@@ -239,7 +239,10 @@ print("Current sys.path:")
 for p in sys.path:
     print(p)
 
-torch.set_default_device('cuda')
+# Use CPU when a GPU driver is not available. This prevents crashes on machines
+# without CUDA support.
+device = 'cuda' if torch.cuda.is_available() else 'cpu'
+torch.set_default_device(device)
 
 """
 This file trains a model for every ARC-AGI task in a split.
@@ -622,11 +625,13 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     start_time = time.time()
-    torch.set_default_device('cuda')
+    # Default to GPU when available; otherwise use CPU so training still runs.
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    torch.set_default_device(device)
     task_nums = list(range(1000))
     split = "training"  # "training", "evaluation, or "test"
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = torch.device(device)
     # device = "cpu"
 
     # Preprocess all tasks, make models, optimizers, and loggers. Make plots.

--- a/utils/object_adapter.py
+++ b/utils/object_adapter.py
@@ -1,7 +1,10 @@
 # utils/object_adapter.py
 import numpy as np
 import torch
-from objutil import all_pureobjects_from_grid                # 直接复用你现有实现
+try:
+    from objutil import all_pureobjects_from_grid  # external dependency
+except ImportError:  # Fallback to a simple local implementation
+    from .objutil_stub import all_pureobjects_from_grid
 
 # ── 全局可调整参数 ───────────────────────────────────────────────
 # param ＝ 3-bool 组合列表，跟你以前 main 流程里的保持一致即可

--- a/utils/objutil_stub.py
+++ b/utils/objutil_stub.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+# Minimal implementation of all_pureobjects_from_grid used when the external
+# objutil package is not available. It extracts 4-connected components for each
+# color (excluding background) and returns them as sets of (color,(r,c)).
+
+def all_pureobjects_from_grid(param, pair_id, in_or_out, grid, shape, background_color=None):
+    h, w = shape
+    grid = np.array(grid)
+    visited = np.zeros_like(grid, dtype=bool)
+    objects = []
+
+    for i in range(h):
+        for j in range(w):
+            color = grid[i, j]
+            if background_color is not None and color == background_color:
+                continue
+            if visited[i, j]:
+                continue
+            # BFS to gather component
+            stack = [(i, j)]
+            visited[i, j] = True
+            pixels = []
+            while stack:
+                x, y = stack.pop()
+                pixels.append((color, (x, y)))
+                for dx, dy in [(-1,0),(1,0),(0,-1),(0,1)]:
+                    nx, ny = x+dx, y+dy
+                    if 0 <= nx < h and 0 <= ny < w:
+                        if not visited[nx, ny] and grid[nx, ny] == color:
+                            visited[nx, ny] = True
+                            stack.append((nx, ny))
+            if pixels:
+                objects.append(frozenset(pixels))
+    return objects


### PR DESCRIPTION
## Summary
- allow CPU fallback when CUDA isn't available
- add placeholder object extractor for missing dependency
- reduce verbosity and debug hole features in preprocessing
- adjust scripts to use available device

## Testing
- `python -m py_compile analyze_example.py arc_compressor.py parallel_train.py preprocessing.py solve_task.py train.py utils/object_adapter.py utils/objutil_stub.py`
- `python train.py --task_name 0a2355a6 --save_steps 2 --resume` *(fails later due to manual interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6842469c1b148323b8bd1370d2a57c47