### PR TITLE
Add hole-color debug outputs

### DIFF
--- a/rulelayers/sparse_rule_layer.py
+++ b/rulelayers/sparse_rule_layer.py
@@ -53,6 +53,9 @@ class SparseRuleLayer(nn.Module):
             mask_i  = obj_masks[i]
             p_i     = params_raw[i,k]
             H, W     = mask_i.shape
+            if op_name == "recolor_mask":
+                color_id = p_i.softmax(dim=0).argmax().item()
+                print(f"[DBG Rule] obj={i} op=recolor_mask color={color_id}")
             if canvas.dim() == 1 or canvas.numel() < mask_i.numel():
                 print(f"[DEBUG] before {op_name}: canvas.shape={canvas.shape}, "
                     f"mask.shape={mask_i.shape}, obj_id={i}")

--- a/train.py
+++ b/train.py
@@ -287,7 +287,9 @@ def take_step(task, model, optimizer, train_step, train_history_logger, folder, 
         start = attr_registry.key_index("holes")
         dim   = 9                             # 若改成 5，改这里
         holes_vec = task.output_attr_tensor[idx_sample][:, start:start+dim]
+        hole_counts = holes_vec.argmax(dim=1).tolist()
         print("[CHK] holes row0-4 =", holes_vec[:5].tolist())
+        print(f"[DBG {train_step}] hole count per obj:", hole_counts[:5])
 
         # -- ② selector argmax ---------------------------
         sel_logits = model.rule_layer.selector(task.output_attr_tensor[idx_sample])
@@ -311,6 +313,8 @@ def take_step(task, model, optimizer, train_step, train_history_logger, folder, 
         # print("Predicted colors per obj:", color_ids[:5])
         print(f"[DBG {train_step}] selector idx per obj:", sel.tolist())
         print(f"[DBG {train_step}] color id per obj  :", color_ids[:5])
+        mapping = list(zip(hole_counts, color_ids))
+        print(f"[DBG {train_step}] hole->color mapping (first 5):", mapping[:5])
 
 
 


### PR DESCRIPTION
## Summary
- add debug output for hole counts and mapping to predicted colors
- log color predictions from SparseRuleLayer when recoloring

## Testing
- `python -m py_compile train.py rulelayers/sparse_rule_layer.py`

------
https://chatgpt.com/codex/tasks/task_e_68425aa044c08323987c15e4b59ec2de