### PR TITLE
Implement mask dedup and tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ matplotlib==3.10.0
 numpy==2.2.2
 torch==2.5.1
 tqdm==4.66.6
+pandas

--- a/tests/test_object_adapter.py
+++ b/tests/test_object_adapter.py
@@ -1,0 +1,25 @@
+import unittest
+import numpy as np
+from utils.object_adapter import dedup_masks, _flood_fill_holes
+
+class TestObjectAdapter(unittest.TestCase):
+    def test_dedup_masks(self):
+        masks = [
+            np.array([[1,0],[1,0]], dtype=bool),
+            np.array([[1,0],[1,0]], dtype=bool),
+            np.array([[0,1],[0,1]], dtype=bool),
+        ]
+        objs = [{'id':0},{'id':1},{'id':2}]
+        new_objs, new_masks, keep = dedup_masks(objs, masks, iou_thr=0.9)
+        self.assertEqual(len(new_masks), 2)
+        self.assertEqual(len(new_objs), 2)
+        self.assertListEqual(keep, [0,2])
+
+    def test_flood_fill_holes(self):
+        mask = np.array([[1,1,1],[1,0,1],[1,1,1]], dtype=bool)
+        self.assertEqual(_flood_fill_holes(mask), 1)
+        mask2 = np.array([[1,1,1,1],[1,0,0,1],[1,1,1,1],[1,1,1,1]], dtype=bool)
+        self.assertEqual(_flood_fill_holes(mask2), 1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- deduplicate overlapping object masks using IoU-NMS
- check for accidental overlap
- expose hole counting and deduplication via unit tests
- add pandas to requirements for testing

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68425fcc77488323ad3f3c21b8722df5