### PR TITLE
Add hole count assertion during preprocessing

### DIFF
--- a/preprocessing.py
+++ b/preprocessing.py
@@ -144,12 +144,13 @@ class Task:
                     if original_grid.shape[0] == 0 or original_grid.shape[1] == 0:
                         raise ValueError(f"Grid shape {original_grid.shape} is invalid, must be non-empty.")
 
-                    from utils.object_adapter import extract_objects_from_grid
+                    from utils.object_adapter import extract_objects_from_grid, assert_holes_consistency
                     obj_d, obj_m, obj_a = extract_objects_from_grid(
                         grid=np.array(original_grid),  # 必须二维
                         pair_id=new_idx,
                         in_or_out=mode
                     )
+                    assert_holes_consistency(obj_d, obj_m)
                     if mode == 'input':
                         self.input_obj_dicts.append(obj_d)
                         self.input_obj_masks.append(obj_m)

--- a/utils/object_adapter.py
+++ b/utils/object_adapter.py
@@ -115,3 +115,14 @@ def _flood_fill_holes(mask: np.ndarray) -> int:
                 holes += 1
     print(f"[DEBUG] Found {holes} holes in mask of shape {mask.shape}")
     return holes
+
+
+def assert_holes_consistency(obj_dicts, masks):
+    """Recompute holes from ``masks`` and assert they match ``obj_dicts``."""
+    for i, mask in enumerate(masks):
+        recomputed = _flood_fill_holes(mask.cpu().numpy())
+        print(f"obj {i}: color={obj_dicts[i]['color']} holes={recomputed}")
+        assert recomputed == obj_dicts[i]["holes"], (
+            f"Hole count mismatch for object {i}: "
+            f"expected {obj_dicts[i]['holes']}, got {recomputed}"
+        )


### PR DESCRIPTION
## Summary
- insert `assert_holes_consistency` call in preprocessing loop
- ensure masks and stored hole counts stay in sync

## Testing
- `python -m py_compile preprocessing.py utils/object_adapter.py`
- ❌ `preprocess_tasks` (torch install failed: 403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_684262631a9c832380bbafca1a15cbc0